### PR TITLE
Tries to fix ChatManager

### DIFF
--- a/src/me/aberdeener/vaultcore/listeners/ChatManager.java
+++ b/src/me/aberdeener/vaultcore/listeners/ChatManager.java
@@ -41,7 +41,8 @@ public class ChatManager implements Listener {
             // The player has staff chat toggled. Format staff chat.
 
             String message = (ChatColor.translateAlternateColorCodes('&',
-                    VaultCore.getInstance().getConfig().getString("staffchat-prefix"))) + (prefix + name + ChatColor.DARK_GRAY + " » " + ChatColor.WHITE + ChatColor.AQUA
+                    VaultCore.getInstance().getConfig().getString("staffchat-prefix"))) + (ChatColor.translateAlternateColorCodes('&', VaultCore.getChat().getPlayerPrefix(player))
+                + player.getDisplayName() + ChatColor.translateAlternateColorCodes('&', VaultCore.getChat().getPlayerSuffix(player)) + ChatColor.DARK_GRAY + " » " + ChatColor.WHITE + ChatColor.AQUA
                     + ChatColor.translateAlternateColorCodes('&',
                     e.getMessage().charAt(0) == "," ? e.getMessage().replaceFirst(",", "") : e.getMessage()
                     /* If e. (...) charAt (...) Then use e.get (...) replaceFirst else use e.getMessage() */));
@@ -93,11 +94,11 @@ public class ChatManager implements Listener {
                 
                 // Find the world group index of this player
                 int thisGroup = -1;
-                for (int i = 0; i < worldGroups.length; i++) {
-                    String[] worlds = worldGroups[i];
+                for (int j = 0; j < worldGroups.length; j++) {
+                    String[] worlds = worldGroups[j];
                     for (String world : worlds) {
                         if (world.equalsIgnoreCase(x.getWorld().getName())) {
-                            thisGroup = i;
+                            thisGroup = j;
                             break;
                         }
                     }


### PR DESCRIPTION
Always cancelling the event - in general isn't a good practice and this overrides any other possible changes from other plugins. It might cause conflicts and errors, and requires reimplementation of some logic for example logging messages to the console.

The following is a fix. Instead of using cancelling and manually sending messages to achieve per-world chat, it uses `getRecipients()` to alter the recipients therefore requires no cancelling.

This PR fixes:
* Staff chat being sent to the public when starting message with `,`
* Modification for chat format (`AsyncPlayerChatEvent#getFormat`) later on or having a higher priority is being overridden.
* Clientside issues with manually sending chat.